### PR TITLE
Fix Bridge_Rest_Mods_Comments::get_children_count()

### DIFF
--- a/includes/mods-comments.php
+++ b/includes/mods-comments.php
@@ -63,11 +63,10 @@ class Bridge_Rest_Mods_Comments {
 	 * @return int
 	 */
 	protected static function get_children_count( $comment ) {
-		$children = $comment->get_children( array(
+		return $comment->get_children( array(
 			'status' => 'approve',
+			'count'  => true,
 		));
-
-		return count( $children );
 	}
 
 


### PR DESCRIPTION
* Add the `count` arg
* Return the result directly